### PR TITLE
Review auto-save, removed.txt fix, redirect_to on word edit/delete, H…

### DIFF
--- a/leaftheme/main.py
+++ b/leaftheme/main.py
@@ -502,7 +502,7 @@ def review_start():
 
 @app.route('/review/apply', methods=['POST'])
 def review_apply():
-    """Apply SM-2 ratings, save leaftheme.json to Drive, redirect to saved confirmation."""
+    """Apply SM-2 ratings, save both files to Drive, redirect to confirmation page."""
     data = flask.request.get_json()
     results = data.get('results', {})  # {word_uid: quality}
     theme_id = data.get('theme_id')
@@ -510,23 +510,25 @@ def review_apply():
     srs_key = 'reverse_srs' if direction == 'reverse' else 'forward_srs'
 
     lt_data = _load_leaftheme()
-
     for uid, quality in results.items():
         _apply_srs(lt_data, srs_key, uid, quality)
-
     _save_leaftheme(lt_data)
 
-    # Save leaftheme.json to Drive immediately after each batch
-    drive_saved = False
+    # Save both files to Drive and clear the unsaved flag
     try:
         if 'credentials' in flask.session:
+            save_dictionary_to_drive(
+                flask.session['credentials'],
+                flask.session['dict_file_id'],
+                flask.session['file_name']
+            )
             save_leaftheme_to_drive(
                 flask.session['credentials'],
                 flask.session.get('leaftheme_file_id'),
                 flask.session.get('wt_folder_id'),
                 flask.session['file_name']
             )
-            drive_saved = True
+            _clear_unsaved()
     except Exception:
         pass  # Don't break the review if Drive save fails
 


### PR DESCRIPTION
…eaven-only SRS stats

- review/apply now saves both .wt and leaftheme.json to Drive after each batch, then redirects to a new /review/saved confirmation page (Progress saved ✓, Continue N / Stop for now). UNSAVED flag is cleared on Drive save and set on any local change to either file.
- Fixed removed.txt format: first field is always '1' (type indicator), not the word integer ID. Confirmed working against Android app — words now correctly disappear on sync after web-app deletion.
- Word edit and delete forms now capture redirect_to from Referer/query param and return there after save/delete (same pattern as add_word).
- SRS due/reviewed/never stats and distributions on /stats now scoped to Heaven words only, consistent with review routes.
- HEAVEN_SAMPLE_DICT added to test_routes.py for review tests that require a Heaven-named theme; updated CLAUDE.md with removed.txt format, redirect_to behaviour, and Heaven-only SRS scope.