### PR TITLE
Reading screen: annotated text with voikko analysis popovers

### DIFF
--- a/leaftheme/main.py
+++ b/leaftheme/main.py
@@ -1,9 +1,11 @@
+import html as _html
 import io
 import json
 import os
 import random
 import struct
 import zipfile
+from urllib.parse import quote_plus
 
 import flask
 
@@ -857,6 +859,70 @@ def stats():
                                  month_data=json.dumps(month_data))
 
 
+_CLASS_BADGE = {
+    'nimisana':   'bg-info text-dark',
+    'teonsana':   'bg-primary',
+    'adjektiivi': 'bg-success',
+    'adverbi':    'bg-warning text-dark',
+    'asemosana':  'bg-secondary',
+}
+
+
+def _word_popup_html(token):
+    """Build Bootstrap popover HTML content for a word token."""
+    parts = []
+    for e in token['entries']:
+        base = _html.escape(e['base'] or '')
+        trans = _html.escape(e['translation']) if e['translation'] else None
+        word_class = e.get('word_class') or ''
+        word_id = e.get('word_id')
+
+        badge = _CLASS_BADGE.get(word_class, 'bg-secondary')
+
+        line = f'<div class="wt-pe border rounded px-2 py-1 mb-1"><span class="fw-medium">{base}</span>'
+        if trans:
+            line += f' \u2013 {trans}'
+        if word_class:
+            line += f' <span class="badge {badge}">{_html.escape(word_class)}</span>'
+        if word_id is not None:
+            line += f' <a href="/word/{word_id}" class="text-secondary ms-1 text-decoration-none">&#x2197;</a>'
+        line += '</div>'
+        parts.append(line)
+
+    if not any(e['translation'] for e in token['entries']):
+        first_base = token['entries'][0]['base'] if token['entries'] else token['src']
+        parts.append(f'<a href="/add_word?word={quote_plus(first_base)}" class="small">+ Add</a>')
+
+    return ''.join(parts)
+
+
+@app.route('/reading', methods=['GET', 'POST'])
+def reading():
+    wt_dict, file_name = _load_dictionary()
+    if wt_dict is None:
+        return flask.redirect('load_dictionary')
+
+    import read as _read
+
+    input_text = ''
+    tokens = None
+
+    if flask.request.method == 'POST':
+        input_text = flask.request.form.get('text', '').strip()
+        if input_text:
+            tokens = _read.analyze_text(input_text, wt_dict)
+            for tok in tokens:
+                if tok['type'] == 'word':
+                    tok['popup_html'] = _word_popup_html(tok)
+                elif tok['type'] == 'word_unanalyzed':
+                    tok['popup_html'] = f'<a href="/add_word?word={quote_plus(tok["src"])}" class="small">+ Add</a>'
+
+    return flask.render_template('reading.html',
+                                 menu_items=get_menu_items(),
+                                 input_text=input_text,
+                                 tokens=tokens)
+
+
 @app.route('/save_dictionary')
 def save_dictionary():
     if 'credentials' not in flask.session:
@@ -1107,6 +1173,7 @@ def get_menu_items():
         out.append(('Add Word', "/add_word"))
         out.append(('Review', "/review"))
         out.append(('Stats', "/stats"))
+        out.append(('Reading', "/reading"))
     else:
         out.append(("Load Dictionary", "/load_dictionary"))
     out.append(("Logout", "/clear"))

--- a/leaftheme/templates/base.html
+++ b/leaftheme/templates/base.html
@@ -67,5 +67,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="{{ url_for('static', filename='js/scripts.js')}}"></script>
+        {% block scripts %}{% endblock %}
     </body>
 </html>

--- a/leaftheme/templates/reading.html
+++ b/leaftheme/templates/reading.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="mt-4">
+    <h2>Reading</h2>
+
+    <form method="POST" action="/reading">
+        <div class="mb-3">
+            <textarea name="text" class="form-control" rows="5"
+                      placeholder="Paste Finnish text here…">{{ input_text }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Analyze</button>
+    </form>
+
+    {% if tokens is not none %}
+    <hr class="my-4">
+    <div class="reading-text mt-3">{% for tok in tokens %}{% if tok.type == 'punct' %}{{ tok.src }}{% else %}<span class="wt-word {% if tok.has_translation %}wt-known{% else %}wt-analyzed{% endif %}" tabindex="0" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="{{ tok.popup_html }}" data-bs-trigger="click focus">{{ tok.src }}</span>{% endif %}{% endfor %}</div>
+    {% endif %}
+</div>
+
+<style>
+.reading-text {
+    font-size: 1.15rem;
+    line-height: 2.4;
+    white-space: pre-wrap;
+}
+.wt-word {
+    cursor: pointer;
+    border-radius: 2px;
+    padding: 0 1px;
+    transition: background 0.1s;
+}
+.wt-word:hover, .wt-word:focus {
+    background: rgba(0, 0, 0, 0.07);
+    outline: none;
+}
+.wt-pe {
+    font-size: 0.875rem;
+    min-width: 170px;
+}
+.popover {
+    max-width: 300px;
+}
+</style>
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+    const triggers = [...document.querySelectorAll('[data-bs-toggle="popover"]')];
+    const popovers = triggers.map(el => new bootstrap.Popover(el, { sanitize: false }));
+    document.addEventListener('click', e => {
+        if (!e.target.closest('[data-bs-toggle="popover"]')) {
+            popovers.forEach(p => p.hide());
+        }
+    });
+})();
+</script>
+{% endblock %}

--- a/read.py
+++ b/read.py
@@ -1,0 +1,184 @@
+TEXT = '''
+Herään arkisin aina kello 7. Pidän rauhallisista aamuista, joten herään yleensä ajoissa. Viikonloppuisin saatan nukkua hieman pidempään. Aamulla teen aamupalaa ja keitän kahvin. Aamupalaa syön lukiessa päivän lehteä. Yleensä syön kaurapuuroa lisukkeilla, mutta joskus saatan tehdä voileivän tai syödä jugurttia myslillä.
+Sitten vaihdan vaatteet ja valmistaudun työpäivään. Työpäivä alkaa kello 9, joten lähden kotoa aina kello 8:30. Menen töihin linja-autolla. Aamuisin on yleensä ruuhkaa ja bussi on melkein aina täynnä. Joskus olen töissä vasta kello 9:10.
+Päivällä käyn työkavereiden kanssa lounaalla ravintolassa. Olen töissä kello 17 asti. Onneksi en jää koskaan ylitöihin. Töiden jälkeen hoidan usein keskustassa asioita, käyn kaupassa tai tapaan ystäviä. Sitten menen kotiin. Joskus käyn illalla kuntosalilla, katson televisiota tai luen kirjaa. Joskus teen vähän töitä kotona illalla. Joko minä tai tyttöystäväni tekee illallisen - yleensä vuorottelemme. Illalla katsomme aina kymmenen uutiset ja sen jälkeen aloitamme iltapuuhat ja menemme nukkumaan.
+'''
+
+import re
+import pyvoikko
+from leaftheme.dictionary import Dictionary
+import json
+
+_current_dict = None  # set by analyze_text()
+
+
+def get_translation(lemma):
+    if _current_dict is None:
+        return None
+    for word in _current_dict.words.values():
+        if word.word == lemma.lower():
+            return word.translation
+    return None
+
+
+def analyse(token):
+    if token == 'Viikonloppuisin':
+        pass
+    analysis = pyvoikko.analyse(token.lower())
+    out = []
+    for x in analysis:
+        if x.CLASS in ['etunimi', 'sukunimi'] and len(analysis) > 1:
+            continue
+        out.append((x.BASEFORM.replace('--', '-'), x.CLASS))
+    return out
+
+
+def process_tokens(tokens):  # Returns (src word, base form (to lookup/add), translation, classes)
+    prev_word = None
+    prev_result = None
+    for word in tokens:
+        if prev_word:
+            if get_translation(f"{prev_word} {word}"):
+                yield f"{prev_word} {word}", f"{prev_word} {word}", get_translation(f"{prev_word} {word}"), None
+                prev_word = word
+                prev_result = None
+                continue
+            else:
+                if prev_result:
+                    yield prev_result
+        if get_translation(word):
+            prev_result = (word, word, get_translation(word), None)
+        else:
+            analysis = analyse(word)
+            if analysis:
+                baseforms = [b for b, c in analysis]
+                classes = [c for b, c in analysis]
+                prev_result = (word, baseforms, [get_translation(b) for b in baseforms], classes)
+            else:
+                prev_result = (word, word, 'None', None)
+        prev_word = word
+    if prev_result:
+        yield prev_result
+
+
+def _find_word_obj(lemma):
+    if _current_dict is None:
+        return None
+    for word in _current_dict.words.values():
+        if word.word == lemma.lower():
+            return word
+    return None
+
+
+def _make_entries(base, trans, classes=None):
+    """Convert process_tokens output to a list of entry dicts."""
+    def _entry(b, t, c):
+        w = _find_word_obj(b)
+        return {
+            'base': b,
+            'translation': t if t and t != 'None' else None,
+            'word_class': c,
+            'word_id': w.id if w else None,
+        }
+
+    if isinstance(base, list):
+        cls = classes or [None] * len(base)
+        return [_entry(b, t, c) for b, t, c in zip(base, trans, cls)]
+    return [_entry(base, trans, classes)]
+
+
+def _tokenize(text):
+    """Yield (token, is_word) pairs preserving all original characters.
+    Hyphens between letters (e.g. jalkapallo-ottelua) are kept inside the word token.
+    """
+    for m in re.finditer(r'[a-zA-ZäöåÄÖÅ]+(?:-[a-zA-ZäöåÄÖÅ]+)*|[^a-zA-ZäöåÄÖÅ]+', text):
+        tok = m.group()
+        yield tok, tok[0].isalpha()
+
+
+def analyze_text(text, wt_dict):
+    """
+    Analyze Finnish text and return a list of display tokens.
+
+    Token types:
+      'punct'           — spaces/punctuation, 'src' key only
+      'word'            — analyzed word: 'src', 'entries', 'has_translation'
+      'word_unanalyzed' — word with no analysis (last-word edge case): 'src', 'popup_html'
+    """
+    global _current_dict
+    _current_dict = wt_dict
+    try:
+        pairs = list(_tokenize(text))
+        words = [tok for tok, is_word in pairs if is_word]
+
+        analyzed = list(process_tokens(words))
+
+        # Map each word position to its analysis; bigrams span two positions
+        analysis_by_pos = {}
+        pos = 0
+        for src, base, trans, classes in analyzed:
+            wc = len(src.split())
+            for i in range(pos, pos + wc):
+                analysis_by_pos[i] = (src, base, trans, classes, wc, pos)
+            pos += wc
+
+        display = []
+        word_pos = 0
+        bigram_end = -1  # skip punct/words consumed by a bigram
+
+        pair_idx = 0
+        while pair_idx < len(pairs):
+            tok, is_word = pairs[pair_idx]
+            if not is_word:
+                if word_pos <= bigram_end:
+                    pair_idx += 1
+                    continue
+                display.append({'type': 'punct', 'src': tok})
+            else:
+                info = analysis_by_pos.get(word_pos)
+                if info is None:
+                    display.append({'type': 'word_unanalyzed', 'src': tok})
+                elif word_pos != info[5]:
+                    pass  # non-first word of a bigram, already merged
+                else:
+                    src, base, trans, classes, wc, _ = info
+                    if wc > 1:
+                        bigram_end = word_pos + wc - 1
+                    entries = _make_entries(base, trans, classes)
+                    display.append({
+                        'type': 'word',
+                        'src': src,
+                        'entries': entries,
+                        'has_translation': any(e['translation'] for e in entries),
+                    })
+                word_pos += 1
+            pair_idx += 1
+
+        return display
+    finally:
+        _current_dict = None
+
+
+def main():
+    import sys
+    sys.stdout.reconfigure(encoding='utf-8')
+    path = "9fb425ac-e028-4b4b-8d7c-3b22ef723c32/dictionary.txt"
+    with open(path, encoding="utf8") as f:
+        d = Dictionary(json.load(f))
+
+    tokens = analyze_text(TEXT, d)
+    for tok in tokens:
+        if tok['type'] == 'punct':
+            print(tok['src'])
+        elif tok['type'] == 'word_unanalyzed':
+            print(tok['src'])
+        else:
+            tip = ' | '.join(
+                f"{e['base']} \u2013 {e['translation']}"
+                for e in tok['entries'] if e['translation']
+            ) or tok['src']
+            print(tok['src'], tip)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ google-api-python-client
 rapidfuzz
 beautifulsoup4
 requests
+pyvoikko


### PR DESCRIPTION
New /reading route lets you paste Finnish text and get every word annotated with its baseform(s), translation, and grammatical class (from pyvoikko). Clicking a word opens a Bootstrap popover showing stacked entry cards — one per baseform — with an Add link when the word isn't in the dictionary yet. Hyphenated compounds (e.g. linja-autolla) are kept as one token. Words are plain until hovered (light background highlight), keeping the text readable.

- read.py: regex tokeniser replacing nltk; analyse() returns (baseform, CLASS) tuples; process_tokens yields 4-tuples incl. classes; analyze_text() maps results back to original positions handling bigrams; last-word yield fix
- main.py: _word_popup_html builds per-entry HTML with class badges colour-coded by grammatical class; /reading GET/POST route; Reading added to sidebar menu; {% block scripts %} slot in base.html
- requirements.txt: add pyvoikko